### PR TITLE
Add unknown BER category for not stated hh age

### DIFF
--- a/docs/buildings/BER-Age-Profiles.md
+++ b/docs/buildings/BER-Age-Profiles.md
@@ -2,7 +2,7 @@
 
 The Dublin BER data was extracted from [SEAI's BER public search database](https://ndber.seai.ie/BERResearchTool/Register/Register.aspx).
 
-Last update: 04/2021 ➡ represents roughly ~287,000 out of ~465,000<sup>[1](#total-buildings)</sup> Dublin buildings.
+Last update: 04/2021 ➡ represents roughly ~287,000 out of ~510,000<sup>[1](#total-buildings)</sup> Dublin buildings.
 
 ## Ratings
 
@@ -19,4 +19,4 @@ As the BER Public database does not yet contain the entire Dublin building stock
 <object type="text/html" data="../../html/ber_estimated_vs_period_built.html" width="750" height="450" frameborder="0"></object>
 
 ---
-<a name="total-buildings"><sup>1</sup></a>The [2016 Census](https://www.cso.ie/en/census/census2016reports/census2016smallareapopulationstatistics/) includes around 434,000 buildings built before 2016 - the additional buildings come from the BER public database.
+<a name="total-buildings"><sup>1</sup></a>The [2016 Census](https://www.cso.ie/en/census/census2016reports/census2016smallareapopulationstatistics/) includes ~480,000 buildings built before 2016 - the additional buildings come from the BER public database.

--- a/docs/buildings/BER-Maps.md
+++ b/docs/buildings/BER-Maps.md
@@ -6,11 +6,11 @@
 
 > **Includes currently geo-coded dwellings that have had a BER completed** ➡ see [SEAI Map](https://www.seai.ie/technologies/seai-maps/ber-map/) for more information. 
 
-> Last update: 07/2020 ➡ represents ~281,000 out of ~465,000<sup>[1](#total-buildings)</sup> Dublin buildings.
+> Last update: 07/2020 ➡ represents ~281,000 out of ~510,000<sup>[1](#total-buildings)</sup> Dublin buildings.
 
-<table style="margin: 0px auto;">
+<table>
     <tr>
-        <th>Period Built</th>
+        <th>Period<br>Built</th>
         <td>before 1919</td>
         <td>1919 - 1945</td>
         <td>1946 - 1960</td>
@@ -20,9 +20,10 @@
         <td>1991 - 2000</td>
         <td>2001 - 2010</td>
         <td>after 2011</td>
+        <td>not stated</td>
     </tr>
     <tr>
-        <th>BER Rating</th>
+        <th>BER<br>Rating</th>
         <td>E</td>
         <td>E</td>
         <td>E</td>
@@ -32,6 +33,7 @@
         <td>D</td>
         <td>C</td>
         <td>A</td>
+        <td>unknown</td>
     </tr>
 </table>
 
@@ -52,4 +54,4 @@
 src="https://renewables.maps.arcgis.com/apps/webappviewer/index.html?id=360f7b3f6f484d7d89b967b41231daef"></iframe>
 
 ---
-<a name="total-buildings"><sup>1</sup></a>The [2016 Census](https://www.cso.ie/en/census/census2016reports/census2016smallareapopulationstatistics/) includes around 434,000 buildings built before 2016 - the additional buildings come from the BER public database.
+<a name="total-buildings"><sup>1</sup></a>The [2016 Census](https://www.cso.ie/en/census/census2016reports/census2016smallareapopulationstatistics/) includes ~480,000 buildings built before 2016 - the additional buildings come from the BER public database.


### PR DESCRIPTION
Had previously excluded the not stated category which
made the stock appear ~60k buildings smaller.  Have now
pulled in these not stated stock by not assigning them
a BER category